### PR TITLE
Support removable tiles

### DIFF
--- a/src/components/ChangeColor.vue
+++ b/src/components/ChangeColor.vue
@@ -7,12 +7,13 @@ defineEmits<{
 }>();
 defineProps<{
   currentColor: Color;
+  disabled: boolean;
 }>();
 const colors: Color[] = ["red", "yellow", "green", "black", "blue"];
 </script>
 
 <template>
-  <div class="ui button simple dropdown">
+  <div class="ui button simple dropdown" :class="{ disabled }">
     <img class="current" :src="standingMeepleSrc(currentColor)" />
     <div class="menu">
       <div>

--- a/src/components/TileBoard.vue
+++ b/src/components/TileBoard.vue
@@ -18,6 +18,7 @@ defineEmits<{
   (e: "editTile", pos: [number, number]): void;
   (e: "placeMeeple", meeplePosIdx: number, pos: [number, number]): void;
   (e: "removeMeeple", pos: [number, number]): void;
+  (e: "removeTile", pos: [number, number]): void;
   (e: "defocus"): void;
 }>();
 const elem = ref<HTMLElement>();
@@ -49,6 +50,7 @@ onMounted(() => {
             :focusing="true"
             @placeMeeple="(idx: number) => $emit('placeMeeple', idx, [y, x])"
             @removeMeeple="() => $emit('removeMeeple', [y, x])"
+            @removeTile="() => $emit('removeTile', [y, x])"
           />
           <TileSquare
             v-else

--- a/src/components/TileSquare.vue
+++ b/src/components/TileSquare.vue
@@ -15,6 +15,7 @@ defineProps<{
 defineEmits<{
   (e: "placeMeeple", idx: number): void;
   (e: "removeMeeple"): void;
+  (e: "removeTile"): void;
   (e: "defocus"): void;
 }>();
 
@@ -36,6 +37,7 @@ const boxStyle = {
       :style="{ transform: `rotate(${tile.Direction * 90}deg)` }"
       :src="tile.Src"
     />
+    <i class="times mini icon remove-tile" @click="$emit('removeTile')"> </i>
     <div
       class="meeple-spots"
       v-for="pos in tile.MeepleablePositions()"
@@ -128,5 +130,11 @@ img {
 }
 img.meeple {
   width: 15px;
+}
+.remove-tile {
+  cursor: pointer;
+  position: absolute;
+  right: -2px;
+  top: 3px;
 }
 </style>

--- a/src/views/SimulatorView.vue
+++ b/src/views/SimulatorView.vue
@@ -133,6 +133,9 @@ const placeMeeple = (meeplePosIdx: number, pos: [number, number]) => {
 const removeMeeple = (pos: [number, number]) => {
   tiles.value[pos[0]][pos[1]]?.RemoveMeeple();
 };
+const removeTile = (pos: [number, number]) => {
+  tiles.value[pos[0]][pos[1]] = null;
+};
 const handleChangeColor = (color: Color) => {
   currentColor.value = color;
 };
@@ -153,6 +156,7 @@ const defocus = () => {
         class="item"
         @changeColor="handleChangeColor"
         :currentColor="currentColor"
+        :disabled="placingTile !== null"
       />
       <NormalButton
         class="item"
@@ -187,6 +191,7 @@ const defocus = () => {
         :focusingPosition="focusingPosition"
         @placeMeeple="placeMeeple"
         @removeMeeple="removeMeeple"
+        @removeTile="removeTile"
         @defocus="defocus"
       />
     </div>


### PR DESCRIPTION
- Support removing of any tiles (with 'times' icon on tiles), in order to make it easy to modify the board once created.
- As a result, this also allows separation of the board into more than one connected parts or removing of all the tiles, but it is fine.