### PR TITLE
Fix frame outline for some browsers

### DIFF
--- a/src/components/TileSquare.vue
+++ b/src/components/TileSquare.vue
@@ -29,8 +29,8 @@ const boxStyle = {
 const tileStyle = (dir: number, frame: Color) => {
   return {
     transform: `rotate(${dir * 90}deg)`,
-    outline: frame !== null ? `1.8px solid ${frame}` : "none",
-    "outline-offset": frame !== null ? "-1.8px" : "none",
+    outline: frame !== null ? `2px solid ${frame}` : "none",
+    "outline-offset": frame !== null ? "-2px" : "none",
   };
 };
 </script>
@@ -135,8 +135,8 @@ img {
   opacity: 0.5;
 }
 .focusing > img {
-  outline: 1.8px solid black;
-  outline-offset: -1.8px;
+  outline: 2px solid black;
+  outline-offset: -2px;
 }
 .empty {
   border-radius: 50%;


### PR DESCRIPTION
It seems that CSS `outline: 1.8px solid black;` doesn't quite work well probably because of the different ways of rounding up or down of decimal numbers in different browsers. In Safari and Firefox (not in Chrome), the outline width was not what I intended, so I just changed it to 2px, which just works fine in any browsers.