### PR TITLE
Fix meeple spots size & board array size

### DIFF
--- a/src/assets/tiles.ts
+++ b/src/assets/tiles.ts
@@ -295,7 +295,7 @@ function newTile(tileKind: Tile): Tile {
   );
 }
 
-const boardSize = 2 * 16 + 1;
+const boardSize = 2 * 20 + 1;
 const initialBoard: (Tile | null)[][] = [];
 for (let i = 0; i < boardSize; i++) {
   const emptyRow: (Tile | null)[] = [];
@@ -330,8 +330,11 @@ function getBoard(): (Tile | null)[][] {
   if (boardStr) {
     const boardWithoutMethods: (Tile | null)[][] = JSON.parse(boardStr);
     const board: (Tile | null)[][] = initialBoard;
-    for (let y = 0; y < boardSize; y++) {
-      for (let x = 0; x < boardSize; x++) {
+    board[(boardSize - 1) / 2][(boardSize - 1) / 2] = null;
+    const ysz = Math.min(boardWithoutMethods.length, board.length);
+    const xsz = Math.min(boardWithoutMethods[0].length, board[0].length);
+    for (let y = 0; y < ysz; y++) {
+      for (let x = 0; x < xsz; x++) {
         if (boardWithoutMethods[y][x]) {
           board[y][x] = newTile(boardWithoutMethods[y][x]!);
         }

--- a/src/components/TileBoard.vue
+++ b/src/components/TileBoard.vue
@@ -30,8 +30,8 @@ onMounted(() => {
   if (elem.value) {
     const panzoom = Panzoom(elem.value, {
       maxScale: 20,
-      startX: -60 * 14,
-      startY: -60 * 14,
+      startX: -60 * 18,
+      startY: -60 * 18,
     });
     if (elem.value.parentElement) {
       elem.value.parentElement.addEventListener("wheel", panzoom.zoomWithWheel);

--- a/src/components/TileSquare.vue
+++ b/src/components/TileSquare.vue
@@ -4,8 +4,8 @@ import type { Color } from "../types";
 import { lyingMeepleSrc, standingMeepleSrc } from "@/assets/meeples";
 
 const tileSize = 60; // px
-const spotRadius = 2; // px
-const spotColor = "#FFDAB9";
+const spotRadius = 4; // px
+const spotColor = "#ffffff";
 
 defineProps<{
   tile: Tile | null;
@@ -77,6 +77,7 @@ const tileStyle = (dir: number, frame: Color) => {
           left: `${tileSize / 2 + (pos.x * tileSize) / 2 - spotRadius}px`,
           top: `${tileSize / 2 - (pos.y * tileSize) / 2 - spotRadius}px`,
           border: `${spotRadius}px solid ${spotColor}`,
+          opacity: 0.7,
         }"
       ></div>
     </div>


### PR DESCRIPTION
- Fix meeple spots. Enlarge the spot circle to make it easier to place a meeple, and change the color so that it looks nice.
- Enlarge the board array size a bit, which is not still enough for the worst case, but is practically large enough. I don't prepare the 144 * 144 array or something because time complexity (of searching for candidate tile spots) also matters here (well, in that case, I can change the algorithm of course, but I don't want to do that either now).